### PR TITLE
feat: add concurrent restoration

### DIFF
--- a/cmd/checkpoint-agent/main.go
+++ b/cmd/checkpoint-agent/main.go
@@ -426,8 +426,9 @@ func main() {
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&lpmv1.PodRestore{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			checkpoint := object.(*lpmv1.PodRestore)
-			return checkpoint.Status.Phase == lpmv1.PodRestorePhasePreparing
+			podRestore := object.(*lpmv1.PodRestore)
+			return podRestore.Status.Phase == lpmv1.PodRestorePhasePreparing &&
+				podRestore.Spec.TargetNode == nodeName
 		})).
 		Complete(podRestoreReconciler); err != nil {
 		logger.Error(err, "Failed to create PodRestore controller")
@@ -858,6 +859,16 @@ func (r *PodRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
+	// Only process if in Preparing phase (guards against retries after phase transition)
+	if podRestore.Status.Phase != lpmv1.PodRestorePhasePreparing {
+		logger.Info("Skipping PodRestore - not in Preparing phase",
+			"namespace", podRestore.Namespace,
+			"name", podRestore.Name,
+			"phase", podRestore.Status.Phase,
+		)
+		return ctrl.Result{}, nil
+	}
+
 	logger.Info("Detected PodRestore CR for restoration",
 		"namespace", podRestore.Namespace,
 		"name", podRestore.Name,
@@ -894,6 +905,7 @@ func (r *PodRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Iterate containers from podSnapshot
 	imagesReady := true
+	statusChanged := false
 	for _, c := range podSnapshot.Spec.Containers {
 		logger.Info("Processing container", "container", c.Name)
 
@@ -922,6 +934,7 @@ func (r *PodRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		// store mapping
 		podRestore.Status.ImageMapping[c.Name] = imageRef
+		statusChanged = true
 		logger.Info("Prepared image for container", "container", c.Name, "image", imageRef)
 	}
 
@@ -930,13 +943,18 @@ func (r *PodRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
 	}
 
-	// Persist image mappings
-	if err := r.Status().Update(ctx, &podRestore); err != nil {
-		logger.Error(err, "Failed to update PodRestore status after image preparation")
-		return ctrl.Result{}, err
+	// Only update status if we actually made changes
+	if statusChanged {
+		if err := r.Status().Update(ctx, &podRestore); err != nil {
+			logger.Error(err, "Failed to update PodRestore status after image preparation")
+			// Return with requeue to retry on conflict
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+		}
+		logger.Info("Updated PodRestore status with new image mappings", "pod", podSnapshot.Name)
 	}
 
 	// Let main controller update phase to PodRestorePhaseRestoring
+	logger.Info("All images prepared for pod restoration", "pod", podSnapshot.Name)
 	return ctrl.Result{}, nil
 }
 

--- a/cmd/checkpoint-agent/main.go
+++ b/cmd/checkpoint-agent/main.go
@@ -427,7 +427,7 @@ func main() {
 		For(&lpmv1.PodRestore{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			checkpoint := object.(*lpmv1.PodRestore)
-			return checkpoint.Status.Phase == lpmv1.PodRestorePhaseRestoring
+			return checkpoint.Status.Phase == lpmv1.PodRestorePhasePreparing
 		})).
 		Complete(podRestoreReconciler); err != nil {
 		logger.Error(err, "Failed to create PodRestore controller")
@@ -863,7 +863,187 @@ func (r *PodRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		"name", podRestore.Name,
 	)
 
+	// Fetch PodCheckpointContent
+	var cpc lpmv1.PodCheckpointContent
+	err := r.Get(ctx, client.ObjectKey{
+		Namespace: podRestore.Namespace,
+		Name:      podRestore.Spec.PodCheckpointContentRef.Name,
+	}, &cpc)
+	if err != nil {
+		logger.Error(err, "Failed to get PodCheckpointContent", "name", podRestore.Spec.PodCheckpointContentRef.Name)
+		return ctrl.Result{}, r.updatePhase(ctx, &podRestore, lpmv1.PodRestorePhaseFailed, fmt.Sprintf("failed to get PodCheckpointContent: %v", err))
+	}
+
+	// Ensure spec.podSnapshot exists
+	if cpc.Spec.PodSnapshot == nil {
+		logger.Error(fmt.Errorf("podSnapshot is nil"), "PodSnapshot is required in PodCheckpointContent")
+		return ctrl.Result{}, r.updatePhase(ctx, &podRestore, lpmv1.PodRestorePhaseFailed, "podSnapshot is required in PodCheckpointContent")
+	}
+
+	// Initialize imageMapping in status if nil
+	if podRestore.Status.ImageMapping == nil {
+		podRestore.Status.ImageMapping = map[string]string{}
+	}
+
+	var podSnapshot corev1.Pod
+	if err := json.Unmarshal(cpc.Spec.PodSnapshot.Raw, &podSnapshot); err != nil {
+		return ctrl.Result{}, r.updatePhase(ctx, &podRestore, lpmv1.PodRestorePhaseFailed, fmt.Sprintf("failed to parse podSnapshot: %v", err))
+	}
+
+	logger.Info("Preparing images for pod restoration", "pod", podSnapshot.Name)
+
+	// Iterate containers from podSnapshot
+	imagesReady := true
+	for _, c := range podSnapshot.Spec.Containers {
+		logger.Info("Processing container", "container", c.Name)
+
+		// skip if already resolved
+		if _, ok := podRestore.Status.ImageMapping[c.Name]; ok {
+			logger.Info("Image already prepared for container", "container", c.Name)
+			continue
+		}
+
+		// find checkpoint artifact for this container
+		checkpointURI := r.getCheckpointPathForContainer(ctx, &cpc, c.Name)
+		if checkpointURI == "" {
+			// if not found, fail early
+			imagesReady = false
+			logger.Info("No checkpoint found for container", "container", c.Name)
+			break
+		}
+
+		imageRef, err := r.convertCheckpointToOCI(ctx, checkpointURI, c.Name)
+		if err != nil {
+			// conversion failed; mark not ready and retry later
+			imagesReady = false
+			logger.Error(err, "Failed to convert checkpoint to OCI image", "container", c.Name, "checkpointURI", checkpointURI)
+			continue
+		}
+
+		// store mapping
+		podRestore.Status.ImageMapping[c.Name] = imageRef
+		logger.Info("Prepared image for container", "container", c.Name, "image", imageRef)
+	}
+
+	if !imagesReady {
+		logger.Info("Not all images are ready yet for pod, requeueing", "pod", podSnapshot.Name)
+		return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
+	}
+
+	// Persist image mappings
+	if err := r.Status().Update(ctx, &podRestore); err != nil {
+		logger.Error(err, "Failed to update PodRestore status after image preparation")
+		return ctrl.Result{}, err
+	}
+
+	// Let main controller update phase to PodRestorePhaseRestoring
 	return ctrl.Result{}, nil
+}
+
+func (r *PodRestoreReconciler) updatePhase(ctx context.Context, podRestore *lpmv1.PodRestore, phase lpmv1.PodRestorePhase, message string) error {
+	podRestore.Status.Phase = phase
+	podRestore.Status.Message = message
+	// mark completion time on terminal phases
+	if phase == "Succeeded" || phase == "Failed" {
+		now := metav1.Now()
+		podRestore.Status.CompletionTime = &now
+	}
+	return r.Status().Update(ctx, podRestore)
+}
+
+// getCheckpointPathForContainer locates the artifactURI inside PodCheckpointContent for a container name
+func (r *PodRestoreReconciler) getCheckpointPathForContainer(ctx context.Context, checkpointContent *lpmv1.PodCheckpointContent, containerName string) string {
+	for _, containerContent := range checkpointContent.Spec.ContainerContents {
+		var content lpmv1.ContainerCheckpointContent
+		err := r.Get(ctx, client.ObjectKey{
+			Name:      containerContent.Name,
+			Namespace: checkpointContent.Namespace,
+		}, &content)
+		if err != nil {
+			// skip missing content; caller will handle not-found case
+			continue
+		}
+
+		// simple heuristic: content name contains container name OR match by ContainerName field
+		if strings.Contains(content.Name, containerName) || content.Spec.ContainerName == containerName {
+			return content.Spec.ArtifactURI
+		}
+	}
+	return ""
+}
+
+func (r *PodRestoreReconciler) convertCheckpointName(checkpointURI string) (string, string, error) {
+	if !strings.HasPrefix(checkpointURI, "shared://") {
+		return "", "", fmt.Errorf("Expected shared:// URI prefix, got: %s", checkpointURI)
+	}
+
+	// Generate OCI image name
+	filename := strings.TrimPrefix(checkpointURI, "shared://")
+	imageName := fmt.Sprintf("localhost/checkpoint:%s", strings.TrimSuffix(filename, ".tar"))
+	checkpointURI = filepath.Join(checkpointsMountPath, filename)
+	return checkpointURI, imageName, nil
+}
+
+// convertCheckpointToOCI converts a checkpoint tar file to OCI image format using buildah
+func (r *PodRestoreReconciler) convertCheckpointToOCI(ctx context.Context, checkpointURI, containerName string) (string, error) {
+	checkpointURI, imageName, err := r.convertCheckpointName(checkpointURI)
+	if err != nil {
+		return "", err
+	}
+
+	// Verify checkpoint file exists
+	if _, err := os.Stat(checkpointURI); os.IsNotExist(err) {
+		return "", fmt.Errorf("checkpoint file not found: %s", checkpointURI)
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Converting checkpoint to OCI image", "checkpointURI", checkpointURI, "imageName", imageName)
+
+	// Common buildah flags to use the mounted container storage
+	buildahFlags := []string{"--root", "/var/lib/containers/storage"}
+
+	// Create a working container from scratch
+	cmd := exec.Command("buildah", append(buildahFlags, "from", "scratch")...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to create working container: %v, output: %s", err, output)
+	}
+
+	containerID := strings.TrimSpace(string(output))
+	logger.Info("Created working container", "containerID", containerID)
+
+	// Clean up working container on exit
+	defer func() {
+		cmd := exec.Command("buildah", append(buildahFlags, "rm", containerID)...)
+		if err := cmd.Run(); err != nil {
+			logger.Info("Warning: failed to remove working container",
+				"containerID", containerID,
+				"error", err)
+		}
+	}()
+
+	// Add checkpoint file to container
+	cmd = exec.Command("buildah", append(buildahFlags, "add", containerID, checkpointURI, "/")...)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to add checkpoint to container: %v", err)
+	}
+
+	// Add checkpoint annotation
+	cmd = exec.Command("buildah", append(buildahFlags, "config",
+		fmt.Sprintf("--annotation=io.kubernetes.cri-o.annotations.checkpoint.name=%s", containerName),
+		containerID)...)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to add checkpoint annotation: %v", err)
+	}
+
+	// Commit the container as an image
+	cmd = exec.Command("buildah", append(buildahFlags, "commit", containerID, imageName)...)
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to commit container as image: %v", err)
+	}
+
+	logger.Info("Successfully created OCI image", "imageName", imageName)
+	return imageName, nil
 }
 
 // convertCheckpointToOCI converts a checkpoint tar file to OCI image format using buildah

--- a/cmd/checkpoint-agent/main.go
+++ b/cmd/checkpoint-agent/main.go
@@ -377,12 +377,6 @@ func main() {
 	}
 	logger.Info("Starting checkpoint agent on node " + nodeName)
 
-	// Ensure checkpoint directory exists
-	if err := os.MkdirAll(checkpointDir, 0755); err != nil {
-		logger.Error(err, "Failed to create checkpoint directory")
-		os.Exit(1)
-	}
-
 	// Build scheme
 	scheme := runtime.NewScheme()
 	if err := lpmv1.AddToScheme(scheme); err != nil {
@@ -404,7 +398,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Setup reconciler
+	// Setup Checkpoint reconciler
 	reconciler := &CheckpointReconciler{
 		Client:   mgr.GetClient(),
 		NodeName: nodeName,
@@ -419,6 +413,24 @@ func main() {
 		})).
 		Complete(reconciler); err != nil {
 		logger.Error(err, "Failed to create controller")
+		os.Exit(1)
+	}
+
+	// Setup PodRestore reconciler
+	podRestoreReconciler := &PodRestoreReconciler{
+		Client:   mgr.GetClient(),
+		NodeName: nodeName,
+	}
+
+	// Watch PodRestore resources
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&lpmv1.PodRestore{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			checkpoint := object.(*lpmv1.PodRestore)
+			return checkpoint.Status.Phase == lpmv1.PodRestorePhaseRestoring
+		})).
+		Complete(podRestoreReconciler); err != nil {
+		logger.Error(err, "Failed to create PodRestore controller")
 		os.Exit(1)
 	}
 
@@ -824,6 +836,34 @@ func (r *CheckpointReconciler) copyToSharedStorage(podUID, containerName, localP
 
 	// Return relative path for shared:// URI
 	return filename, destFile.Sync()
+}
+
+// PodRestoreReconciler handles PodRestore events
+type PodRestoreReconciler struct {
+	client.Client
+	NodeName string
+}
+
+// Reconcile processes PodRestore events
+func (r *PodRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var podRestore lpmv1.PodRestore
+	if err := r.Get(ctx, req.NamespacedName, &podRestore); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Not for this node, skip
+	if podRestore.Spec.TargetNode != r.NodeName {
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("Detected PodRestore CR for restoration",
+		"namespace", podRestore.Namespace,
+		"name", podRestore.Name,
+	)
+
+	return ctrl.Result{}, nil
 }
 
 // convertCheckpointToOCI converts a checkpoint tar file to OCI image format using buildah

--- a/config/agent/rbac.yaml
+++ b/config/agent/rbac.yaml
@@ -12,13 +12,16 @@ rules:
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["lpm.my.domain"]
-  resources: ["containercheckpoints"]
+  resources: ["containercheckpoints", "podrestores"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["lpm.my.domain"]
-  resources: ["containercheckpointcontents"]
+  resources: ["containercheckpointcontents", "podcheckpointcontents"]
   verbs: ["get", "list", "watch", "create"]
 - apiGroups: ["lpm.my.domain"]
   resources: ["containercheckpoints/status"]
+  verbs: ["update"]
+- apiGroups: ["lpm.my.domain"]
+  resources: ["podrestores/status"]
   verbs: ["update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/internal/controller/podrestore_controller.go
+++ b/internal/controller/podrestore_controller.go
@@ -132,6 +132,8 @@ func (r *PodRestoreReconciler) handlePending(ctx context.Context, podRestore *lp
 	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 }
 
+// Node-level agent handles image preparation for containers on the target node
+// We monitor when all images are ready, then transition to Restoring phase
 func (r *PodRestoreReconciler) handlePreparingImages(ctx context.Context, podRestore *lpmv1.PodRestore) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Preparing images for PodRestore", "name", podRestore.Name)
@@ -147,64 +149,40 @@ func (r *PodRestoreReconciler) handlePreparingImages(ctx context.Context, podRes
 		return ctrl.Result{}, r.updatePhase(ctx, podRestore, lpmv1.PodRestorePhaseFailed, "podSpecSnapshot not found in PodCheckpointContent")
 	}
 
-	// Initialize imageMapping in status if nil
-	if podRestore.Status.ImageMapping == nil {
-		podRestore.Status.ImageMapping = map[string]string{}
-	}
-
-	imagesReady := true
-
+	// Parse pod snapshot to determine expected container count
 	var podSnapshot corev1.Pod
 	if err := json.Unmarshal(cpc.Spec.PodSnapshot.Raw, &podSnapshot); err != nil {
 		return ctrl.Result{}, r.updatePhase(ctx, podRestore, lpmv1.PodRestorePhaseFailed, fmt.Sprintf("failed to parse podSnapshot: %v", err))
 	}
 
-	// Iterate containers from podSnapshot
-	for _, c := range podSnapshot.Spec.Containers {
-		// skip if already resolved
-		if _, ok := podRestore.Status.ImageMapping[c.Name]; ok {
-			continue
-		}
-
-		// find checkpoint artifact for this container
-		checkpointURI := r.getCheckpointPathForContainer(ctx, &cpc, c.Name)
-		if checkpointURI == "" {
-			// if not found, fail early
-			imagesReady = false
-			logger.Info("No checkpoint found for container", "container", c.Name)
-			continue
-		}
-
-		imageRef, err := r.convertToOCIImage(ctx, checkpointURI, c.Name, podRestore.Spec.TargetNode)
-		if err != nil {
-			// conversion failed; mark not ready and retry later
-			imagesReady = false
-			logger.Error(err, "Failed to convert checkpoint to OCI image", "container", c.Name, "checkpointURI", checkpointURI)
-			continue
-		}
-
-		// store mapping
-		podRestore.Status.ImageMapping[c.Name] = imageRef
-		logger.Info("Prepared image for container", "container", c.Name, "image", imageRef)
+	// Check if all containers have their images prepared
+	expectedContainers := len(podSnapshot.Spec.Containers)
+	if podRestore.Status.ImageMapping == nil {
+		podRestore.Status.ImageMapping = make(map[string]string)
 	}
+	preparedContainers := len(podRestore.Status.ImageMapping)
 
-	// persist status again once done/partially done
-	if err := r.Status().Update(ctx, podRestore); err != nil {
-		return ctrl.Result{}, err
+	logger.Info("Image preparation progress",
+		"prepared", preparedContainers,
+		"expected", expectedContainers,
+		"mapping", podRestore.Status.ImageMapping)
+
+	// Validate that each container has a non-empty image reference
+	for _, container := range podSnapshot.Spec.Containers {
+		imageRef, exists := podRestore.Status.ImageMapping[container.Name]
+		if !exists || imageRef == "" {
+			return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
+		}
 	}
 
 	// move to restoring only when all containers have images mapped
-	if imagesReady && len(podRestore.Status.ImageMapping) == len(podSnapshot.Spec.Containers) {
-		podRestore.Status.Phase = lpmv1.PodRestorePhaseRestoring
-		podRestore.Status.Message = "creating restored pod"
-		if err := r.Status().Update(ctx, podRestore); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-	}
+	podRestore.Status.Phase = lpmv1.PodRestorePhaseRestoring
+	podRestore.Status.Message = "creating restored pod"
+	if err := r.Status().Update(ctx, podRestore); err != nil {
+		return ctrl.Result{}, err
 
-	// still preparing images; requeue
-	return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
+	}
+	return ctrl.Result{}, nil
 }
 
 func (r *PodRestoreReconciler) handleRestoring(ctx context.Context, podRestore *lpmv1.PodRestore) (ctrl.Result, error) {


### PR DESCRIPTION
Similar to https://github.com/k8s-live-migration-AY2526/live-pod-migration/pull/16, this PR introduces more concurrency to the restoration step of pod migration. Specifically, it moves the responsibility of converting `image.tar` to OCI images from the controller to node-level agents.